### PR TITLE
feat: lift state mode override

### DIFF
--- a/rmf_building_sim_common/include/rmf_building_sim_common/lift_common.hpp
+++ b/rmf_building_sim_common/include/rmf_building_sim_common/lift_common.hpp
@@ -106,6 +106,7 @@ private:
   bool _is_mode_overriden = false;
   uint8_t _overriden_mode = 0;
   uint8_t _previous_mode = 0;
+  std::string _session_id = "";
 
   void publish_door_request(const double time, std::string door_name,
     uint32_t door_state);

--- a/rmf_building_sim_common/src/lift_common.cpp
+++ b/rmf_building_sim_common/src/lift_common.cpp
@@ -295,10 +295,12 @@ LiftCommon::LiftCommon(rclcpp::Node::SharedPtr node,
         _previous_mode = _lift_state.current_mode;
         _is_mode_overriden = true;
         _overriden_mode = msg->override_mode;
+        //session id to be something
+        _session_id = msg->session_id;
 
         RCLCPP_INFO(logger(),
-        "Lift [%s] mode has been overriden from [%d] to [%d]",
-        _lift_name.c_str(), _previous_mode, _overriden_mode);
+        "Lift [%s] mode has been overriden from [%d] to [%d] with session id [%s]",
+        _lift_name.c_str(), _previous_mode, _overriden_mode, _session_id.c_str());
       }
       //if currently it is already overriden
       else if (_is_mode_overriden && msg->is_override_enabled)
@@ -359,6 +361,8 @@ void LiftCommon::pub_lift_state(const double time)
   if (_is_mode_overriden)
   {
     _lift_state.current_mode = _overriden_mode;
+    //publish session id
+    _lift_state.session_id = "AGV45123546";
   }
 
   _lift_state_pub->publish(_lift_state);

--- a/rmf_building_sim_msgs/msg/LiftModeOverride.msg
+++ b/rmf_building_sim_msgs/msg/LiftModeOverride.msg
@@ -10,3 +10,5 @@ uint8 MODE_AGV=2
 uint8 MODE_FIRE=3
 uint8 MODE_OFFLINE=4
 uint8 MODE_EMERGENCY=5
+
+string session_id


### PR DESCRIPTION
-by default, cast AGV45123546 as session id if override (hard coded)
-else, it will replace session id base on the session_id being cast.